### PR TITLE
Removed the dot from filetypes

### DIFF
--- a/grammars/generic-config.cson
+++ b/grammars/generic-config.cson
@@ -1,6 +1,6 @@
 'fileTypes': [
-  '.gitignore'
-  '.conf'
+  'gitignore'
+  'conf'
 ]
 'name': 'Generic Configuration'
 'patterns': [


### PR DESCRIPTION
The plugin wasn't working on my conf files in Windows 7 untill I removed the dot. Looking to other Atom language packages I noticed that they don't put the dot by default.
