### PR TITLE
Add .gitattributes to affected file extensions

### DIFF
--- a/grammars/generic-config.cson
+++ b/grammars/generic-config.cson
@@ -1,4 +1,5 @@
 'fileTypes': [
+  'gitattributes'
   'gitignore'
   'conf'
 ]


### PR DESCRIPTION
Just installed this package, and was a little surprised to see `.gitattributes` wasn't receiving highlighting. The file's a Git-specific configuration file the same way `.gitignore` is, so... yeah. :-)

[Here's an example file](https://github.com/Alhadis/Snippets/blob/master/.gitattributes), though I'm sure you've seen one of 'em before.