### PR TITLE
Add support for .ctags, .hgignore, .mailmap, and .stylelintignore

### DIFF
--- a/grammars/generic-config.cson
+++ b/grammars/generic-config.cson
@@ -2,6 +2,10 @@
   'gitattributes'
   'gitignore'
   'conf'
+  'ctags'
+  'hgignore'
+  'mailmap'
+  'stylelintignore'
 ]
 'name': 'Generic Configuration'
 'patterns': [


### PR DESCRIPTION
Exactly as advertised. Each file uses a Git-style syntax for comments, adorned with little else.

### Examples:
* [`.ctags`](https://github.com/universal-ctags/ctags/blob/master/.ctags)
* [`.hgignore`](https://www.selenic.com/mercurial/hgignore.5.html#example)
* [`.mailmap`](https://github.com/git/git/blob/master/.mailmap)
* [`.stylelintignore`](https://github.com/stylelint/stylelint/blob/bc7ec1a0b0604dd511cb3b7160f46dd13cc5e6d7/src/__tests__/fixtures/ignore_config/.stylelintignore)