### PR TITLE
Add support for gitignores other than .gitignore

### DIFF
--- a/grammars/generic-config.cson
+++ b/grammars/generic-config.cson
@@ -1,5 +1,7 @@
 'fileTypes': [
   'gitattributes'
+  '.config/git/ignore'
+  '.git/info/exclude'
   'gitignore'
   'conf'
   'ctags'


### PR DESCRIPTION
As is documented [here](https://git-scm.com/docs/gitignore), we can also put gitignore files in `$HOME/.config/git/ignore` or `$GIT_DIR/info/exclude` as well as well-known `.gitignore`. This PR supports highlighting gitignore files placed in these locations.

![gitignores2](https://cloud.githubusercontent.com/assets/13291527/19796177/62def1ac-9d1d-11e6-933b-669db9908e58.jpg)

At first, I was planning to specify `ignore` as a gitignore file, but this was too generic IMO. Instead, I used `.config/git/ignore` assuming this is utilized in cases where global gitignore is managed in a so-called dotfiles repository. I will change it to `git/ignore` or even `ignore` if it's preferred.

I also assumed `$GIT_DIR` is set to default (i.e., `.git`) because I don't think it's worth the effort even if it's possible to detect the value of an environmental variable.

<!--links-->
